### PR TITLE
Update shell scripts, additional book making

### DIFF
--- a/mods-processes/postprocess-preserve-compounds-select-books.pl
+++ b/mods-processes/postprocess-preserve-compounds-select-books.pl
@@ -14,7 +14,7 @@ foreach my $infile (@files)
     my $outfile = $infile;
     $outfile =~ s/^$inputdir/$outputdir/o;
 	
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates.xsl");
+	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates-template.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.2 -s:_tmp.1 -xsl:cdm-mods-final-level-to-compounds.xsl islandora-namespace=ui");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.3 -s:_tmp.2 -xsl:cdm-mods-select-compounds-to-books.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:$outfile -s:_tmp.3 -xsl:cdm-mods-updates-single-children.xsl");

--- a/mods-processes/postprocess-preserve-compounds.pl
+++ b/mods-processes/postprocess-preserve-compounds.pl
@@ -14,7 +14,7 @@ foreach my $infile (@files)
     my $outfile = $infile;
     $outfile =~ s/^$inputdir/$outputdir/o;
 	
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates.xsl");
+	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates-template.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.2 -s:_tmp.1 -xsl:cdm-mods-final-level-to-compounds.xsl islandora-namespace=ui");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:$outfile -s:_tmp.2 -xsl:cdm-mods-updates-single-children.xsl");
 

--- a/mods-processes/postprocess-to-books-select.pl
+++ b/mods-processes/postprocess-to-books-select.pl
@@ -14,7 +14,7 @@ foreach my $infile (@files)
     my $outfile = $infile;
     $outfile =~ s/^$inputdir/$outputdir/o;
 	
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates.xsl");
+	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates-template.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.2 -s:_tmp.1 -xsl:cdm-mods-updates-single-children.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:$outfile -s:_tmp.2 -xsl:cdm-mods-final-level-to-books-select.xsl islandora-namespace=ui");
 

--- a/mods-processes/postprocess-to-books.pl
+++ b/mods-processes/postprocess-to-books.pl
@@ -14,12 +14,12 @@ foreach my $infile (@files)
     my $outfile = $infile;
     $outfile =~ s/^$inputdir/$outputdir/o;
 	
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates.xsl");
+	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates-template.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.2 -s:_tmp.1 -xsl:cdm-mods-updates-single-children.xsl");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:$outfile -s:_tmp.2 -xsl:cdm-mods-final-level-to-books.xsl islandora-namespace=ui");
 
 }
 
-unlink("_tmp.*");
+# unlink("_tmp.*");
 
 system("time /t"); # time end


### PR DESCRIPTION
- Update shells scripts to use latest xsl for global alterations, uiowa-mods-updates-template.xsl. Strongly recommend removing deprecated uiowa-mods-updates.xsl from the repo
- Add additional book making: Standard output of the crosswalk module leaves ContentDM single level compounds as they are - they ingest into Islandora as compounds. These were previously left unaltered by the cdm-mods-final-level-to-books.xsl transform. It has been updated by this PR to make them into books if they contain only image objects.