### PR TITLE
assemble pioneer select books/preserve compound process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /mods-processes/in/bak/*.*
 /mods-processes/out/*.*
 /mods-processes/_tmp.*
+/mods-processes/tree.xml

--- a/mods-maps/uiowa-mods-crosswalk-pioneerLives2.xml
+++ b/mods-maps/uiowa-mods-crosswalk-pioneerLives2.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd"
+    version="3.6">
+    
+    <titleInfo>
+        <title><?cdm-element-name title?></title>
+    </titleInfo>
+    
+    <name type="personal">
+        <namePart><?cdm-element-name creator?></namePart>
+        <role>
+            <roleTerm type="text" authority="marcrelator">creator</roleTerm>
+        </role>
+    </name>
+    
+    <originInfo>
+        <publisher><?cdm-element-name publisher?></publisher>
+        <dateCreated keyDate="yes"><?cdm-element-name date-original?></dateCreated>
+        <dateCaptured><?cdm-element-name date-digital?></dateCaptured>
+    </originInfo>
+    
+    <abstract>
+        <?cdm-element-name description?>
+    </abstract>
+    
+    <note type="note"><?cdm-element-name note?></note>
+    
+    <subject authority="lctgm">
+        <topic><?cdm-element-name topical-subject-lctgm?></topic>
+    </subject>
+    
+    <subject authority="lcsh">
+        <topic><?cdm-element-name topical-subject-lcsh?></topic>
+    </subject>
+    
+    <subject authority="lcsh">
+        <name type="personal">
+            <namePart><?cdm-element-name personal-name-subject?></namePart>
+        </name>
+    </subject>
+    
+    <subject authority="lcsh">
+        <name type="corporate">
+            <namePart><?cdm-element-name corporate-name-subject?></namePart>
+        </name>
+    </subject>
+    
+    <subject authority="lcsh">
+        <geographic><?cdm-element-name geographic-subject?></geographic>
+    </subject>
+    
+    <subject>
+        <temporal><?cdm-element-name chronological-subject?></temporal>
+    </subject>
+    
+    <genre authority="dct"><?cdm-element-name dcmi-type?></genre>
+    
+    <genre authority="aat"><?cdm-element-name aat-type?></genre>
+    
+    <genre authority="imt"><?cdm-element-name imt-type?></genre>
+    
+    <relatedItem type="host" displayLabel="Digital Collection">
+        <identifier type="collectionName"><?cdm-element-name digital-collection?></identifier>
+    </relatedItem>
+    
+    <name type="corporate" authority="lcsh">
+        <namePart><?cdm-element-name contributing-institution?></namePart>
+        <role>
+            <roleTerm authority="marcrelator" type="text">contributor</roleTerm>
+        </role>
+    </name>
+    
+    <relatedItem type="host" displayLabel="Archival Collection">
+        <titleInfo>
+            <title><?cdm-element-name archival-collection?></title>
+        </titleInfo>
+        <identifier><?cdm-element-name collection-identifier?></identifier>
+    </relatedItem>
+    
+    <relatedItem type="series">
+        <titleInfo>
+            <title><?cdm-element-name series?></title>
+        </titleInfo>
+        <identifier><?cdm-element-name series-number?></identifier>
+    </relatedItem>
+    
+    <relatedItem type="series" displayLabel="Box and Folder">
+        <identifier><?cdm-element-name box-number?></identifier>
+        <identifier><?cdm-element-name folder-number?></identifier>
+        <titleInfo>
+            <title><?cdm-element-name folder-name?></title>
+        </titleInfo>
+    </relatedItem>
+    
+    <relatedItem type="isReferencedBy" displayLabel="Collection Guide">
+        <location>
+            <url><?cdm-element-name collection-guide?></url>
+        </location>
+    </relatedItem>	
+    
+    <physicalDescription>
+        <extent unit="height"><?cdm-element-name height-cm?></extent>
+        <extent unit="width"><?cdm-element-name width-cm?></extent>
+    </physicalDescription>
+    
+    <accessCondition type="use and reproduction">
+        <?cdm-element-name rights-management?>
+    </accessCondition>
+    
+    <note type="contact information"><?cdm-element-name contact-information?></note>
+    
+    <recordInfo displayLabel="Uploaded by">
+        <recordContentSource><?cdm-element-name uploaded-by?></recordContentSource>        
+    </recordInfo>
+    
+    <recordInfo displayLabel="Cataloged by">
+        <recordContentSource><?cdm-element-name cataloged-by?></recordContentSource>
+    </recordInfo>
+    
+    
+    <!-- DO NOT REMOVE ANY OF THE FOLLOWING CONTENT -->
+    
+    <!-- This will map the file extension to a content model -->
+    <relatedItem otherType="islandoraCModel" otherTypeAuth="dgi">
+        <identifier><?cdm-element-name contentdm-fileName?></identifier>
+    </relatedItem>
+    
+    <!-- assign collection -->
+    <relatedItem otherType="islandoraCollection" otherTypeAuth="dgi"/>
+    
+    <!-- assign parent/child relationships -->
+    <relatedItem otherType="isChildOf" otherTypeAuth="dgi"/>
+    
+    <!-- This will embed a link the ingest process can follow to retrieve the digital object to place
+         in the OBJ datastream. This PI must be mapped to the element that has the ContentDM item url. -->
+    <relatedItem otherType="OBJ" otherTypeAuth="dgi">
+        <?cdm-element-name item-url?>
+    </relatedItem>
+    
+    
+    <!-- This will temporarily embed the original ContentDM data. It is retrieved by the ingest process and stored
+         in a CDM datastream. -->
+    <relatedItem otherType="CDMDatastream" otherTypeAuth="dgi">
+        <extension><?cdm-element-name record?></extension>
+    </relatedItem>
+    
+    <!-- This will temporarily embed the full text data. It is retrieved by the ingest process and stored
+         in a FULLTEXT datastream. -->
+    <relatedItem otherType="FULLTEXTDatastream" otherTypeAuth="dgi">
+        <extension>
+            <FULLTEXT><?cdm-element-name full-text?></FULLTEXT>
+        </extension>
+    </relatedItem>
+    
+</mods>
+

--- a/mods-processes/cdm-mods-final-level-to-books-select-pioneer.xsl
+++ b/mods-processes/cdm-mods-final-level-to-books-select-pioneer.xsl
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mods="http://www.loc.gov/mods/v3"
+    xmlns:cdm="http://www.oclc.org/contentdm"
+    exclude-result-prefixes="xs" 
+    version="2.0">
+
+    <!-- Template to change to books:
+         - final level in hierarchy, i.e. the last collection without a subcollection
+         - compounds with only large image children
+    -->
+    <!-- This is not handling any single page books at this point, i.e. changing them to standalone images. -->
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+    <xsl:strip-space elements="*"/>
+
+    <xsl:param name="islandora-namespace" required="yes"/>
+    <xsl:variable name="islandora-namespace-prefix" select="concat($islandora-namespace,':')"/>
+
+    
+    <!-- build hierarchy for reference, top level collections then recurse; top level compounds -->
+    <xsl:variable name="tree" exclude-result-prefixes="#all">
+        <tree>
+            <xsl:for-each
+                select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier[. = 'islandora:collectionCModel']][mods:relatedItem[@otherType = 'islandoraCollection'][not(contains(., '_'))]]">
+                <xsl:variable name="node-id" select="concat($islandora-namespace-prefix,mods:identifier[@type = 'islandora'])"/>
+                <xsl:variable name="cmodel"
+                    select="mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier"/>
+                <!-- This xsl:if/@test will filter out nodes that should be candidates to become a book. 
+                     The test can be changed as needed, this is just an example that would only allow collections objects
+                     containing 'scrapbook' in the title to be processed into books.
+                     See 2nd location below where this test is also applied.
+                -->
+                <xsl:if test="matches(lower-case(mods:titleInfo/mods:title), '(minutes|diary|album|ledger|register)')">
+                    <xsl:call-template name="recurse-nodes">
+                        <xsl:with-param name="node-id" select="$node-id"/>
+                        <xsl:with-param name="cmodel" select="$cmodel"/>
+                    </xsl:call-template>
+                </xsl:if>
+            </xsl:for-each>
+            <xsl:for-each select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier[. = 'islandora:compoundCModel']]">
+                <xsl:variable name="node-id" select="mods:identifier[@type = 'islandora']"/>
+                <xsl:variable name="cmodel"
+                    select="mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier"/>
+                <!-- in the standard module crosswalk, ONLY single level compounds are created, 
+                     so no recursion is needed to list the children -->
+                <!-- this is the second location the test needs to be applied for selectively creatings
+                     as with preceding, this is just an example
+                -->
+                <xsl:if test="matches(lower-case(mods:titleInfo/mods:title), '(minutes|diary|album|ledger|register)')">
+                    <node id="{$node-id}" cmodel="{$cmodel}">
+                        <xsl:for-each
+                            select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'isChildOf']/mods:identifier[. = $node-id]]">
+                            <xsl:variable name="node-id"
+                                select="mods:identifier[@type = 'islandora']"/>
+                            <xsl:variable name="cmodel"
+                                select="mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier"/>
+                            <node id="{$node-id}" cmodel="{$cmodel}"/>
+                        </xsl:for-each>
+                    </node>
+                </xsl:if>
+            </xsl:for-each>
+        </tree>
+    </xsl:variable>
+
+    <xsl:template name="recurse-nodes" exclude-result-prefixes="#all">
+        <xsl:param name="node-id"/>
+        <xsl:param name="cmodel"/>
+        <node id="{substring-after($node-id,$islandora-namespace-prefix)}" cmodel="{$cmodel}">
+            <xsl:for-each
+                select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'islandoraCollection']/mods:identifier[. = $node-id]]">
+                <xsl:variable name="node-id" select="concat($islandora-namespace-prefix,mods:identifier[@type = 'islandora'])"/>
+                <xsl:variable name="cmodel"
+                    select="mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier"/>
+                <xsl:call-template name="recurse-nodes">
+                    <xsl:with-param name="node-id" select="$node-id"/>
+                    <xsl:with-param name="cmodel" select="$cmodel"/>
+                </xsl:call-template>
+            </xsl:for-each>
+        </node>
+    </xsl:template>
+
+   <!-- make collections with one level of image children a book -->
+    <xsl:template match="mods:mods/mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier[. = 'islandora:collectionCModel']" exclude-result-prefixes="#all">
+        <xsl:variable name="identifier" select="ancestor::mods:mods/mods:identifier[@type = 'islandora']"/>
+        <xsl:choose>
+            <!-- when this collection only has image children make it a book -->
+            <xsl:when test="$tree//node[@id = $identifier][not(descendant::node[@cmodel = 'islandora:collectionCModel']) and not(node[not(matches(@cmodel,'image'))])]">
+                <identifier xmlns="http://www.loc.gov/mods/v3">islandora:bookCModel</identifier>
+            </xsl:when>
+            <!--  or let it be -->
+            <xsl:otherwise><xsl:copy-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- make compounds with one level of image children a book -->
+    <xsl:template match="mods:mods/mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier[. = 'islandora:compoundCModel']" exclude-result-prefixes="#all">
+        <xsl:variable name="identifier" select="ancestor::mods:mods/mods:identifier[@type = 'islandora']"/>
+        <xsl:choose>
+            <!-- when this compound only has image children make it a book -->
+            <xsl:when test="$tree//node[@id = $identifier][not(node[not(matches(@cmodel,'image'))])]">
+                <identifier xmlns="http://www.loc.gov/mods/v3">islandora:bookCModel</identifier>
+            </xsl:when>
+            <!--  or let it be -->
+            <xsl:otherwise><xsl:copy-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+
+    <!-- This template addresses the collection relationship of image records that are not the child of a compound.
+         If the record has no non-image siblings and is to become a book page, the relationship type is 
+         changed from islandoraCollection to isPageOf, otherwise it is copied through. 
+         In this case removal of the collection association and creating the isPageOf relationship can be 
+         handled in one template. Two subsequent templates handle image records that are the child of a compound.
+    -->
+    <xsl:template match="mods:mods[not(mods:relatedItem[@otherType = 'isChildOf'])][matches(mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier,'image')]/mods:relatedItem[@otherType = 'islandoraCollection']" exclude-result-prefixes="#all">
+        <xsl:variable name="identifier" select="parent::mods:mods/mods:identifier[@type = 'islandora']"/>
+        <xsl:variable name="book-identifier" select="normalize-space(mods:identifier)"/>
+        <xsl:choose>
+            <xsl:when test="$tree//node[@id = $identifier][not(parent::node/node[@cmodel = 'islandora:collectionCModel'])][not(parent::node/node[not(matches(@cmodel,'image'))])]">
+                <relatedItem xmlns="http://www.loc.gov/mods/v3" otherType="isPageOf" otherTypeAuth="dgi">
+                    <identifier>
+                        <xsl:call-template name="book-identifier">
+                            <xsl:with-param name="book-identifier" select="$book-identifier"/>
+                        </xsl:call-template>
+                    </identifier>
+                </relatedItem>
+            </xsl:when>
+            <xsl:otherwise><xsl:copy-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- Handling image records that are compound children requires two templates. This template tests: If 
+         the record has no non-image siblings and is to become a book page, the relationship type is changed 
+         from isChildOf to isPageOf, otherwise it is copied through.
+         A subsequent template handles removal of the collection relationship if a record is changed to a
+         book page.
+    -->
+    <xsl:template match="mods:mods[mods:relatedItem[@otherType = 'isChildOf']][matches(mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier,'image')]/mods:relatedItem[@otherType = 'isChildOf']" exclude-result-prefixes="#all">
+        <xsl:variable name="identifier" select="parent::mods:mods/mods:identifier[@type = 'islandora']"/>
+        <xsl:variable name="book-identifier" select="normalize-space(mods:identifier)"/>
+        <xsl:choose>
+            <xsl:when test="$tree//node[@id = $identifier][not(parent::node/node[@cmodel = 'islandora:collectionCModel'])][not(parent::node/node[not(matches(@cmodel,'image'))])]">
+                <relatedItem xmlns="http://www.loc.gov/mods/v3" otherType="isPageOf" otherTypeAuth="dgi">
+                    <identifier>
+                        <xsl:call-template name="book-identifier">
+                            <xsl:with-param name="book-identifier" select="$book-identifier"/>
+                        </xsl:call-template>
+                    </identifier>
+                </relatedItem>
+            </xsl:when>
+            <xsl:otherwise><xsl:copy-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- See preceding template. This template, which also addresses compound children, tests: 
+        If the record has no non-image siblings and is to become a book page, the relationship
+        to a collection is removed, otherwise it is copied through.  -->
+    <xsl:template match="mods:mods[mods:relatedItem[@otherType = 'isChildOf']][matches(mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier,'image')]/mods:relatedItem[@otherType = 'islandoraCollection']" exclude-result-prefixes="#all">
+        <xsl:variable name="identifier" select="parent::mods:mods/mods:identifier[@type = 'islandora']"/>
+        <xsl:variable name="book-identifier" select="normalize-space(mods:identifier)"/>
+        <xsl:choose>
+            <xsl:when test="$tree//node[@id = $identifier][not(parent::node/node[@cmodel = 'islandora:collectionCModel'])][not(parent::node/node[not(matches(@cmodel,'image'))])]"/>
+            <!-- or let it be -->
+            <xsl:otherwise><xsl:copy-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="book-identifier">
+        <xsl:param name="book-identifier" as="xs:string" required="yes"/>
+        <xsl:choose>
+            <xsl:when test="contains($book-identifier,':')">
+                <xsl:value-of select="substring-after($book-identifier,':')"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$book-identifier"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!-- have to change cModel for the image objects that will become pages 
+         this works for both compounds and collections
+    -->
+    <xsl:template match="mods:mods/mods:relatedItem[@otherType = 'islandoraCModel'][mods:identifier[matches(.,'image')]]" exclude-result-prefixes="#all">
+        <xsl:variable name="identifier" select="parent::mods:mods/mods:identifier[@type = 'islandora']"/>
+        <xsl:variable name="book-identifier" select="parent::mods:mods/mods:relatedItem[@otherType = 'islandoraCollection']/mods:identifier"/>
+        <xsl:choose>
+            <!-- when: parent is a container, does not have any subcollections, and none of its children are not images, 
+                 it's a page so replace child relationship with collection to isPageOf -->
+            <xsl:when test="$tree//node[@id = $identifier][not(parent::node/node[@cmodel = 'islandora:collectionCModel'])][not(parent::node/node[not(matches(@cmodel,'image'))])]">
+                <relatedItem xmlns="http://www.loc.gov/mods/v3" otherType="islandoraCModel" otherTypeAuth="dgi">
+                    <identifier>islandora:pageCModel</identifier>
+                </relatedItem>
+            </xsl:when>
+            <!-- or let it be -->
+            <xsl:otherwise><xsl:copy-of select="."/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+
+    <!-- identity transform to copy through all nodes (except those with specific templates modifying them -->    
+    <xsl:template match="/" exclude-result-prefixes="#all">
+        <xsl:copy>
+            <xsl:apply-templates/>
+        </xsl:copy>
+        <xsl:result-document href="tree.xml" method="xml" indent="yes">
+            <xsl:copy-of select="$tree"/>
+        </xsl:result-document>
+    </xsl:template>
+
+    <xsl:template match="* | @*" exclude-result-prefixes="#all">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | *| text() | comment() | processing-instruction()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- keep comments and PIs						-->
+    <xsl:template match="comment() | processing-instruction()">
+        <xsl:copy-of select="."/>
+    </xsl:template>
+
+   
+</xsl:stylesheet>

--- a/mods-processes/postprocess-to-books-select-pioneer.pl
+++ b/mods-processes/postprocess-to-books-select-pioneer.pl
@@ -14,11 +14,10 @@ foreach my $infile (@files)
     my $outfile = $infile;
     $outfile =~ s/^$inputdir/$outputdir/o;
 	
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates-template.xsl");
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.2 -s:_tmp.1 -xsl:cdm-mods-select-compounds-to-books.xsl");
+	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:uiowa-mods-updates-pioneerLives2.xsl");
+	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.2 -s:_tmp.1 -xsl:cdm-mods-final-level-to-books-select-pioneer.xsl islandora-namespace=ui");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.3 -s:_tmp.2 -xsl:cdm-mods-final-level-to-compounds.xsl islandora-namespace=ui");
 	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:$outfile -s:_tmp.3 -xsl:cdm-mods-updates-single-children.xsl");
-
 }
 
 unlink("_tmp.*");

--- a/mods-processes/uiowa-mods-updates-pioneerLives2.xsl
+++ b/mods-processes/uiowa-mods-updates-pioneerLives2.xsl
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:saxon="http://saxon.sf.net/"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mods="http://www.loc.gov/mods/v3"
+    xmlns:cdm="http://www.oclc.org/contentdm"
+    exclude-result-prefixes="xs"  extension-element-prefixes="saxon"
+    version="2.0">
+    
+    <!-- Template for cleanup of ContentDM-to-MODS crosswalk output prior to ingest to Islandora.  -->
+    
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+    
+    <xsl:strip-space elements="*"/>
+    
+    
+    <!-- identity transform to copy through all nodes (except those with specific templates modifying them) -->    
+    <xsl:template match="/" exclude-result-prefixes="#all">
+        <xsl:copy>
+            <xsl:apply-templates/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="* | @*" exclude-result-prefixes="#all">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | *| text() | comment() | processing-instruction()"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- keep comments and PIs						-->
+    <xsl:template match="comment() | processing-instruction()">
+        <xsl:copy-of select="."/>
+    </xsl:template>
+    
+    <!-- updates -->
+    <!-- fix values of typeOfResource to conform to MODS schema. -->
+    <!-- To date only case issues -->
+    <xsl:template match="mods:typeOfResource" exclude-result-prefixes="#all">
+        <typeOfResource xmlns="http://www.loc.gov/mods/v3"><xsl:value-of select="lower-case(normalize-space(.))"/></typeOfResource>
+    </xsl:template>
+    
+    <!-- simultaneous cleanup of subjects with more than one topic and topic values that need to be split -->
+    <xsl:template match="mods:subject[mods:topic and not(mods:name)]" exclude-result-prefixes="#all">
+        <xsl:variable name="subject-attributes" select="@*"/>
+        <xsl:for-each select="mods:topic">
+            <xsl:for-each select="tokenize(.,';')">
+                <subject xmlns="http://www.loc.gov/mods/v3">
+                    <xsl:copy-of select="$subject-attributes"/>
+                    <topic><xsl:value-of select="normalize-space(.)"/></topic>
+                </subject>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <xsl:template match="mods:subject[not(mods:topic) and mods:name]" exclude-result-prefixes="#all">
+        <xsl:variable name="subject-attributes" select="@*"/>
+        <xsl:for-each select="mods:name/mods:namePart[normalize-space()]">
+            <xsl:variable name="namepart-siblings" select="*[not(self::mods:namePart)]"/>
+            <xsl:for-each select="tokenize(.,';')">
+                <subject xmlns="http://www.loc.gov/mods/v3">
+                    <xsl:copy-of select="$subject-attributes"/>
+                    <name>
+                        <namePart><xsl:value-of select="normalize-space(.)"/></namePart>
+                        <!-- each name should include the namepart siblings -->
+                        <xsl:apply-templates select="$namepart-siblings"/>
+                    </name>
+                </subject>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>   
+    
+    <!--  
+             whether ';' present or not, tokenizing on it will work correctly
+             this approach negates approach using multiple templates to handle
+             multiple namePart and nameParts with ';'
+        -->
+    <xsl:template match="mods:mods/mods:name[mods:namePart[normalize-space()]]" exclude-result-prefixes="#all">
+        <xsl:variable name="name-attributes" select="@*"/>
+        <!-- store sibling elements, e.g. role -->
+        <xsl:variable name="namepart-siblings" select="*[not(self::mods:namePart)]"/>
+        <xsl:for-each select="mods:namePart">
+            <xsl:for-each select="tokenize(.,';')">
+                <name xmlns="http://www.loc.gov/mods/v3">
+                    <xsl:copy-of select="$name-attributes"/>
+                    <namePart><xsl:value-of select="normalize-space(.)"/></namePart>
+                    <!-- each name should include the namepart siblings -->
+                    <xsl:apply-templates select="$namepart-siblings"/>
+                </name>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!--to tokenize temporal subjects-->
+    <xsl:template match="mods:subject[mods:temporal]" exclude-result-prefixes="#all">
+        <xsl:variable name="subject-attributes" select="@*"/>
+        <xsl:for-each select="mods:temporal">
+            <xsl:for-each select="tokenize(.,';')">
+                <subject xmlns="http://www.loc.gov/mods/v3">
+                    <xsl:copy-of select="$subject-attributes"/>
+                    <temporal><xsl:value-of select="normalize-space(.)"/></temporal>
+                </subject>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>  
+    
+    <!--to tokenize geographic subjects-->
+    <xsl:template match="mods:subject[mods:geographic]" exclude-result-prefixes="#all">
+        <xsl:variable name="subject-attributes" select="@*"/>
+        <xsl:for-each select="mods:geographic">
+            <xsl:for-each select="tokenize(.,';')">
+                <subject xmlns="http://www.loc.gov/mods/v3">
+                    <xsl:copy-of select="$subject-attributes"/>
+                    <geographic><xsl:value-of select="normalize-space(.)"/></geographic>
+                </subject>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>         
+    
+    <!--   to tokenize genre-->
+    <xsl:template match="mods:genre" exclude-result-prefixes="#all">
+        <xsl:variable name="genre-attributes" select="@*"/>
+        <xsl:for-each select="tokenize(.,';')">
+            <genre xmlns="http://www.loc.gov/mods/v3">
+                <xsl:copy-of select="$genre-attributes"/>
+                <xsl:value-of select="normalize-space(.)"/>
+            </genre>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <!--   to tokenize publishers -->
+    <xsl:template match="mods:originInfo[mods:publisher]" exclude-result-prefixes="#all">
+        <xsl:variable name="originInfo-attributes" select="@*"/>
+        <xsl:for-each select="mods:publisher">
+            <xsl:for-each select="tokenize(.,';')">
+                <originInfo xmlns="http://www.loc.gov/mods/v3">
+                    <xsl:copy-of select="$originInfo-attributes"/>
+                    <publisher><xsl:value-of select="normalize-space(.)"/></publisher>
+                </originInfo>
+            </xsl:for-each>
+        </xsl:for-each>
+    </xsl:template>
+    
+    
+    
+    <!-- conflate latitude and longitude into a single /mods/subject/cartographics/coordinates
+         Note that this relies on the mapping having both in the same /mods/subject, and in the correct order.
+    -->
+    <xsl:template match="mods:subject[count(mods:cartographics/mods:coordinates[normalize-space()]) = 2]" exclude-result-prefixes="#all">
+        <subject xmlns="http://www.loc.gov/mods/v3">
+            <cartographics>
+                <coordinates><xsl:value-of select="concat(mods:cartographics/mods:coordinates[1],', ',mods:cartographics/mods:coordinates[2])"/></coordinates>
+            </cartographics>
+        </subject>
+    </xsl:template>
+    
+    <!-- geo parsing -->
+    <xsl:template match="mods:subject[mods:geographic[contains(.,'--')]]" exclude-result-prefixes="#all">
+        <xsl:for-each select="tokenize(mods:geographic,';')">
+            <xsl:variable name="geo-raw" select="normalize-space(.)"/>
+            <xsl:variable name="geo-cooked" select="replace($geo-raw,'\s*--\s*','--')"/>
+            <xsl:variable name="token-count" select="count(tokenize($geo-cooked,'--'))"/>
+            <subject xmlns="http://www.loc.gov/mods/v3">
+                <xsl:if test="tokenize($geo-cooked,'--')[1]='United States'"> 
+                    <xsl:choose>
+                        <xsl:when test="$token-count = 4">
+                            <hierarchicalGeographic xmlns="http://www.loc.gov/mods/v3">
+                                <country><xsl:value-of select="tokenize($geo-cooked,'--')[1]"/></country>
+                                <state><xsl:value-of select="tokenize($geo-cooked,'--')[2]"/></state>
+                                <county><xsl:value-of select="tokenize($geo-cooked,'--')[3]"/></county>
+                                <city><xsl:value-of select="tokenize($geo-cooked,'--')[4]"/></city>
+                            </hierarchicalGeographic>
+                        </xsl:when>
+                        <xsl:when test="$token-count = 3">
+                            <hierarchicalGeographic xmlns="http://www.loc.gov/mods/v3">
+                                <country><xsl:value-of select="tokenize($geo-cooked,'--')[1]"/></country>
+                                <state><xsl:value-of select="tokenize($geo-cooked,'--')[2]"/></state>
+                                <city><xsl:value-of select="tokenize($geo-cooked,'--')[3]"/></city>
+                            </hierarchicalGeographic>
+                        </xsl:when>
+                        <xsl:when test="$token-count = 2">
+                            <hierarchicalGeographic xmlns="http://www.loc.gov/mods/v3">
+                                <country><xsl:value-of select="tokenize($geo-cooked,'--')[1]"/></country>
+                                <state><xsl:value-of select="tokenize($geo-cooked,'--')[2]"/></state>
+                            </hierarchicalGeographic>
+                        </xsl:when>
+                        
+                        <!-- always have default processing -->
+                        <xsl:otherwise>
+                            <xsl:copy-of select="."/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:if>
+                <xsl:if test="tokenize($geo-cooked,'--')[1]!='United States'"> 
+                    <geographic><xsl:copy-of select="."/></geographic>
+                </xsl:if>  
+            </subject>
+        </xsl:for-each>
+        
+    </xsl:template>
+    
+    <!-- child objects should have title of their parents -->
+    <xsl:template match="mods:mods[mods:relatedItem[@otherType = 'isChildOf']]/mods:titleInfo/mods:title" exclude-result-prefixes="#all">
+        <!-- get parent title -->
+        <xsl:variable name="parent-id" select="ancestor::mods:mods/mods:relatedItem[@otherType = 'isChildOf']/mods:identifier"/>
+        <xsl:variable name="parent-title" select="ancestor::mods:modsCollection/mods:mods[mods:identifier[@type = 'islandora'][. = $parent-id]]/mods:titleInfo[not(@type)][1]/mods:title"/>
+        <title xmlns="http://www.loc.gov/mods/v3"><xsl:value-of select="$parent-title"/></title>
+    </xsl:template>
+    
+    <!-- target collections in the uni namespace -->
+    <xsl:template match="mods:relatedItem[@otherType='islandoraCollection']/mods:identifier" exclude-result-prefixes="#all">
+        <identifier xmlns="http://www.loc.gov/mods/v3"><xsl:value-of select="replace(.,'islandora:','uni:')"/></identifier>
+    </xsl:template>
+    
+    <!-- conflate height and width? TBC -->
+    <xsl:template match="mods:physicalDescription[mods:extent[@unit = 'height'][normalize-space()] and mods:extent[@unit = 'width'][normalize-space()]]" exclude-result-prefixes="#all">
+        <!--<xsl:template match="mods:physicalDescription/mods:extent" exclude-result-prefixes="#all">-->
+        <physicalDescription xmlns="http://www.loc.gov/mods/v3">
+            <!-- process all other children -->
+            <xsl:apply-templates select="*[not(self::mods:extent[matches(@unit,'(height|width)')])]"/>
+            <!-- build new extent -->
+            <!--<extent><xsl:value-of select="concat(mods:physicalDescription/mods:extent[1],' x ',mods:physicalDescription/mods:extent[2], ' cm')"/></extent>-->
+            
+            <extent><xsl:value-of select="concat(mods:extent[@unit = 'height'], ' × ', mods:extent[@unit = 'width'], ' cm')"/></extent>
+        </physicalDescription>
+    </xsl:template>
+    <!--</xsl:template>-->
+    
+    <!-- remove some empty elements -->
+    <xsl:template match="mods:name[not(mods:namePart[normalize-space()])]
+        | mods:genre[not(normalize-space())]
+        | mods:extent[not(normalize-space())]
+        | mods:physicalDescription[not(*[normalize-space()])]
+        | mods:subject[mods:cartographics][not(mods:cartographics/mods:coordinates[normalize-space()])]
+        | mods:typeOfResource[not(normalize-space())]
+        | mods:language[not(mods:languageTerm[normalize-space()])]
+        | mods:relatedItem/mods:extension/*:FULLTEXT[not(normalize-space())]
+        | mods:accessCondition[not(normalize-space())]
+        | mods:note[not(normalize-space())]
+        | mods:relatedItem[@type = 'host'][mods:identifier[@type = 'collectionName'] or not(*)]
+        | mods:relatedItem[@otherType = 'FULLTEXTDatastream'][normalize-space(mods:extension) = '']"/>
+</xsl:stylesheet> 


### PR DESCRIPTION
- fix cdm-mods-final-level-to-books-select-pioneer.xsl to use matches() and correct regex
- create shell script postprocess-to-books-select-pioneer.pl with correct transform sequence
- assumes: desired result is selected books, remaining hierarchy to compounds
- ambigous match issues with uiowa-mods-updates-pioneerLives2 NOT addressed
- added uiowa-mods-crosswalk-pioneerLives2 to mods-processes